### PR TITLE
Add an option for notes.

### DIFF
--- a/content.js
+++ b/content.js
@@ -24,6 +24,9 @@ const CONVENTIONAL_COMMENTS = {
   praise: {
     icon: "thumbs-up",
   },
+  note: {
+    icon: "sticky-note",
+  },
 };
 
 // Add the UI to the main comment textarea (the one at the bottom of the page)


### PR DESCRIPTION
Hi @nchevobbe! 👋🏼 I love this add-on! What do you think about adding an option for notes? I really like using them to leave breadcrumbs and highlights for reviewers, and to explain why I wrote something a certain way.

Remarkup has a `(NOTE)` callout, too, but I didn't add it as a `stylePrefix`, because I thought the blue background might be a bit too visually heavy compared to the other, more substantive labels.